### PR TITLE
v2.006

### DIFF
--- a/tgreviews.mv
+++ b/tgreviews.mv
@@ -7184,7 +7184,7 @@
 				</MvIF>
 			</MvIF>
 		<MvELSEIF EXPR = "{ [ g.Module_Library_DB ].OrderShipmentList_Load_Order( l.order:id, l.order:shipments ) }">
-			<MvIF EXPR = "{ NOT miva_array_search( l.order:shipments, 1, l.shipment, 'l.shipment:ship_date EQ 0 OR l.shipment:ship_date GT l.timestamp_check' ) }">
+			<MvIF EXPR = "{ NOT miva_array_search( l.order:shipments, 1, l.shipment, 'l.shipment:ship_date EQ 0 OR l.shipment:ship_date GT l.timestamp_check OR l.shipment:status NE 200' ) }">
 				<MvIF EXPR = "{ MailAfter_Email_Trigger( l.order ) }">
 					<MvASSIGN NAME = "l.null" VALUE = "{ [ g.Module_Feature_SCH_DB ].ScheduledTaskLog_Insert( l.task:id, 'I', 'Reviews: Mail After Email triggered for Order \'' $ l.order:id $ '\'' ) }">
 				<MvELSE>


### PR DESCRIPTION
Bugfix: MailAfter_Email_Trigger_All_LowLevel: when shipment is created, ship_date is 0, would trigger off the email.